### PR TITLE
fixup! Move main thread implementation to std::thread to remove as many platform specific functions as possible

### DIFF
--- a/xbmc/threads/platform/win/ThreadImpl.cpp
+++ b/xbmc/threads/platform/win/ThreadImpl.cpp
@@ -41,7 +41,7 @@ void CThread::SetThreadInfo()
 
   info.dwType = 0x1000;
   info.szName = m_ThreadName.c_str();
-  info.dwThreadID = m_lwpId;
+  info.dwThreadID = reinterpret_cast<std::uintptr_t>(m_lwpId);
   info.dwFlags = 0;
 
   __try
@@ -57,7 +57,7 @@ void CThread::SetThreadInfo()
 
 std::thread::native_handle_type CThread::GetCurrentThreadNativeHandle()
 {
-  return ::GetCurrentThreadId();
+  return ::GetCurrentThread();
 }
 
 int CThread::GetMinPriority(void)
@@ -73,11 +73,6 @@ int CThread::GetMaxPriority(void)
 int CThread::GetNormalPriority(void)
 {
   return(THREAD_PRIORITY_NORMAL);
-}
-
-int CThread::GetSchedRRPriority(void)
-{
-  return GetNormalPriority();
 }
 
 bool CThread::SetPriority(const int iPriority)

--- a/xbmc/utils/CryptThreading.cpp
+++ b/xbmc/utils/CryptThreading.cpp
@@ -45,7 +45,7 @@ void lock_callback(int mode, int type, const char* file, int line)
 
 unsigned long thread_id()
 {
-  return (unsigned long)( static_cast<pthread_t>(CThread::GetCurrentThreadNativeHandle()) );
+  return reinterpret_cast<std::uintptr_t>(CThread::GetCurrentThreadNativeHandle());
 }
 
 }

--- a/xbmc/utils/log.cpp
+++ b/xbmc/utils/log.cpp
@@ -214,7 +214,7 @@ bool CLog::WriteLogString(int logLevel, const std::string& logString)
                                   minute,
                                   second,
                                   static_cast<int>(millisecond),
-                                  static_cast<uint64_t>(CThread::GetCurrentThreadNativeHandle()),
+                                  reinterpret_cast<std::uintptr_t>(CThread::GetCurrentThreadNativeHandle()),
                                   levelNames[logLevel]) + strData;
 
   return g_logState.m_platform.WriteStringToLog(strData);


### PR DESCRIPTION
compile tested for
- windows desktop
- windows uwp
- linux x11