### PR TITLE
fixup! Requires C-style casts. 

### DIFF
--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -148,7 +148,7 @@ void CThread::SetThreadInfo()
 
 std::uintptr_t CThread::GetCurrentThreadNativeHandle()
 {
-#if defined(TARGET_DARWIN)
+#if defined(TARGET_DARWIN) || defined(TARGET_FREEBSD)
   return reinterpret_cast<std::uintptr_t>(pthread_self());
 #else
   return pthread_self();

--- a/xbmc/threads/platform/pthreads/ThreadImpl.cpp
+++ b/xbmc/threads/platform/pthreads/ThreadImpl.cpp
@@ -68,13 +68,7 @@ namespace XbmcThreads
 static pid_t GetCurrentThreadPid_()
 {
 #ifdef TARGET_FREEBSD
-#if __FreeBSD_version < 900031
-  long lwpid;
-  thr_self(&lwpid);
-  return lwpid;
-#else
   return pthread_getthreadid_np();
-#endif
 #elif defined(TARGET_ANDROID)
   return gettid();
 #else


### PR DESCRIPTION
compile tested the if defined on our freebsd jenkins builder

removed the `#if __FreeBSD_version < 900031`, looks like you missed my comment